### PR TITLE
mediaType a subPropertyOf encodingFormat

### DIFF
--- a/dcat/rdf/dcat-schema.ttl
+++ b/dcat/rdf/dcat-schema.ttl
@@ -120,7 +120,7 @@ dcat:landingPage
 dcat:mediaType
   schema:domainIncludes dcat:Distribution , schema:DataDownload ;
   schema:rangeIncludes dct:MediaTypeOrExtent , schema:Text , schema:url ;
-  owl:equivalentProperty schema:encodingFormat ;
+  rdsf:subPropertyOf schema:encodingFormat ;
 .
 dcat:record
   schema:domainIncludes dcat:Catalog , schema:DataCatalog ;


### PR DESCRIPTION
Every dcat:mediaType is a kind of schema:encodingFormat, but not every schema:encodingFormat is a kind of dcat:mediaType.

The reason is the domain of dcat:mediaType is a dcat:Distribution. A dcat:Distribution us equivalent to a schema:DataDownload, which is a domain of schema:encodingFormat, via schema:CreativeWork. But schema:encodingFormat has a second domain, of schema:MediaObject. And the use of encodingFormat on MediaObject is not equivalent to dcat:mediaType.

The problem with the alignment is that it is symmetric, but the real world isn't. By changing to a sub-type we keep the alignment in the correct direction only.